### PR TITLE
Fix probes and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ This repository contains an example deployment.yml for deploying 12factor-app-a 
 1. Install and set up [Minikube][minikube] and [kubectl][kubectl]
 1. Checkout this repository, 12factor-app-a and 12factor-app-b
 1. Run `minikube start` if minikube is not already started
-1. Run `eval $(minikube docker-env)` to set up your docker environment in the current terminal to connect to minikube
-1. Change to the `12factor-app-a` directory and run `mvn package -P docker-image`
-1. Change to the `12factor-app-b` directory and run `mvn package -P docker-image`
+1. Run `eval $(minikube docker-env)` to set up your docker environment to connect to minikube
+    * This only affects the current terminal. You must run this command for each terminal where you're going to build a docker image.
+1. Change to the `12factor-app-a` directory and run `mvn package -P docker-image`. This will build the app and the docker image.
+1. Change to the `12factor-app-b` directory and run `mvn package -P docker-image`. This will build the app and the docker image.
 1. Change to the directory for this repository and run `kubectl apply -f deployment.yml`
     * This should deploy and start two instances of each app and expose service A on port 30080 on the minikube IP address
     * You can run `kubectl get pods` to watch your containers starting

--- a/deployment.yml
+++ b/deployment.yml
@@ -24,14 +24,12 @@ spec:
                       - name:  application_rest_ServiceBClient_mp_rest_url 
                         value: "http://openliberty-12factor-app-b-service:9081/demo/b"
                   livenessProbe:
-                      httpGet:
-                          path: "/health"
-                          port: 9080
+                      exec:
+                          command: ["sh", "-c", "curl -s http://localhost:9080/health | grep -q serviceA"]
                       initialDelaySeconds: 60
                   readinessProbe:
-                      httpGet:
-                          path: "/health"
-                          port: 9080
+                      exec:
+                          command: ["sh", "-c", "curl -s http://localhost:9080/health | grep -q serviceA"]
                       initialDelaySeconds: 5
 ---
 
@@ -63,14 +61,12 @@ spec:
                       - name: failFrequency
                         value: "4"
                   livenessProbe:
-                      httpGet:
-                          path: "/health"
-                          port: 9081
+                      exec:
+                          command: ["sh", "-c", "curl -s http://localhost:9081/health | grep -q serviceB"]
                       initialDelaySeconds: 60
                   readinessProbe:
-                      httpGet:
-                          path: "/health"
-                          port: 9081
+                      exec:
+                          command: ["sh", "-c", "curl -s http://localhost:9081/health | grep -q serviceB"]
                       initialDelaySeconds: 5
 ---
 


### PR DESCRIPTION
Change the probe configuration to use curl and check the body of the health response

Update the README section on setting the docker environment to point to minikube.